### PR TITLE
include <cstring> added to avoid memcpy error during compilation

### DIFF
--- a/src/fit_buffer_encode.cpp
+++ b/src/fit_buffer_encode.cpp
@@ -17,6 +17,7 @@
 
 #include "fit_buffer_encode.hpp"
 #include "fit_crc.hpp"
+#include <cstring>
 
 namespace fit
 {

--- a/src/fit_encode.cpp
+++ b/src/fit_encode.cpp
@@ -18,6 +18,7 @@
 #include <iostream>
 #include "fit_encode.hpp"
 #include "fit_crc.hpp"
+#include <cstring>
 
 namespace fit
 {


### PR DESCRIPTION
This solves the install issue mentioned in #2.